### PR TITLE
Github action to build docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,28 +1,67 @@
-name: build docs
+# Workflow to build sphinx doc and deploy to GitHub Pages
+name: Build docs and deploy to Pages
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  docs:
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      # Install sphinx and components
       - name: Install dependencies
         run: |
           pip install sphinx>=5.0.2 sphinx_rtd_theme>=1.3.0 myst_parser==2.0.0
+      # Build with sphinx
       - name: Sphinx build
         run: |
           sphinx-apidoc -o docs_src src/
           sphinx-build -b html docs_src docs
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      # Set permissions for Pages artifact creation and warn if they were incorrect
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "docs/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      # Create and upload Pages artifact from docs dir
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/
-          force_orphan: true
+          path: ./docs
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This creates a **build docs** action that rebuilds the documentation and pushes it to a separate branch, named `gh-pages`. 
In a second step, we can change the settings to use this to publish to pages instead of the current `docs/` directory in `main` branch.
