### PR TITLE
update requirements and drop ansi2html

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 aiodns==3.0.0
 aiohttp==3.8.5
 aiosignal==1.3.1
-ansi2html==1.8.0
 async-timeout==4.0.3
 attrs==23.1.0
 bandit==1.7.5
@@ -11,9 +10,9 @@ cffi==1.15.1
 charset-normalizer==3.2.0
 click==8.1.7
 colorama==0.4.6
-dash==2.13.0
+dash==2.15.0
 dash-bootstrap-components==1.5.0
-dash-bootstrap-templates==1.0.8
+dash-bootstrap-templates==1.1.2
 dash-core-components==2.0.0
 dash-html-components==2.0.0
 dash-table==5.0.0


### PR DESCRIPTION
Update requirements so that we can drop ansi2html

See https://github.com/plotly/dash/pull/2721